### PR TITLE
Deprecate this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Deprecation notice
+This package has been deprecated in favour of the new streaming API of [json2csv](https://github.com/zemirco/json2csv).
+
 # json2csv-stream
 
 [![Build Status](https://travis-ci.org/zemirco/json2csv-stream.png)](https://travis-ci.org/zemirco/json2csv-stream)


### PR DESCRIPTION
Once https://github.com/zemirco/json2csv/pull/235 is merged and released, this project will be obsolete.

I'd advise that you also:
* Add `[Deprecated]` to the title or description of the repo.
* Deprecate it on npm using https://docs.npmjs.com/cli/deprecate